### PR TITLE
Fix: operator precedence in _get_extension_hint()

### DIFF
--- a/hg_mcp/main.py
+++ b/hg_mcp/main.py
@@ -256,8 +256,7 @@ def _get_extension_hint(error_text: str, command_args: list[str]) -> str:
     is_extension_error = (
         "unknown command" in error_text.lower()
         or "unknown command" in error_text
-        or f"'{cmd}'" in error_text
-        and "unknown" in error_text.lower()
+        or (f"'{cmd}'" in error_text and "unknown" in error_text.lower())
     )
 
     if not is_extension_error:


### PR DESCRIPTION
## Summary

Fixes an operator precedence bug in `_get_extension_hint()` where `and` has higher precedence than `or`, causing incorrect boolean logic evaluation.

## Changes

Added parentheses to ensure correct grouping:

```python
# Before (WRONG):
is_extension_error = (
    "unknown command" in error_text.lower()
    or "unknown command" in error_text
    or f"'{cmd}'" in error_text
    and "unknown" in error_text.lower()
)

# After (CORRECT):
is_extension_error = (
    "unknown command" in error_text.lower()
    or "unknown command" in error_text
    or (f"'{cmd}'" in error_text and "unknown" in error_text.lower())
)
```

## Impact

The condition now correctly identifies extension-related errors in all cases, providing helpful hints to users when Mercurial extensions are not enabled.

## Related

Fixes #2